### PR TITLE
VCST-873: Add Public store setting.

### DIFF
--- a/src/VirtoCommerce.ApplicationInsights.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ApplicationInsights.Core/ModuleConstants.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using VirtoCommerce.Platform.Core.Settings;
+
+namespace VirtoCommerce.ApplicationInsights.Core;
+
+public static class ModuleConstants
+{
+    public static class Settings
+    {
+        public static class General
+        {
+            public static SettingDescriptor EnableTracking { get; } = new SettingDescriptor
+            {
+                Name = "ApplicationInsights.EnableTracking",
+                GroupName = "Application Insights",
+                ValueType = SettingValueType.Boolean,
+                DefaultValue = false,
+                IsPublic = true,
+            };
+
+            public static SettingDescriptor InstrumentationKey { get; } = new SettingDescriptor
+            {
+                Name = "ApplicationInsights.InstrumentationKey",
+                GroupName = "Application Insights",
+                ValueType = SettingValueType.ShortText,
+                IsPublic = true,
+            };
+
+            public static IEnumerable<SettingDescriptor> AllSettings
+            {
+                get
+                {
+                    yield return EnableTracking;
+                    yield return InstrumentationKey;
+                }
+            }
+
+        }
+
+        public static IEnumerable<SettingDescriptor> StoreLevelSettings
+        {
+            get
+            {
+                yield return General.EnableTracking;
+                yield return General.InstrumentationKey;
+            }
+        }
+
+    }
+}

--- a/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.813.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Telemetry\" />

--- a/src/VirtoCommerce.ApplicationInsights.Data/VirtoCommerce.ApplicationInsights.Data.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Data/VirtoCommerce.ApplicationInsights.Data.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.22.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Telemetry\" />

--- a/src/VirtoCommerce.ApplicationInsights.Web/Localizations/en.ApplicationInsights.json
+++ b/src/VirtoCommerce.ApplicationInsights.Web/Localizations/en.ApplicationInsights.json
@@ -1,0 +1,14 @@
+{
+	"settings": {
+		"ApplicationInsights": {
+			"EnableTracking": {
+				"title": "Enable",
+				"description": "Activating Azure Application Insights for the Store"
+			},
+			"InstrumentationKey": {
+				"title": "Instrumentation Key",
+				"description": "The instrumentation key of your AppInsights resource on Azure. DefaultValue is automatically loaded from the connection string."
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description
feat: Introduced the Public Store Setting feature, enabling administrators to configure Application Insights and specify the InstrumentationKey per store. Administrators now have the ability to enable Application Insights for specific stores, enhancing monitoring and telemetry capabilities tailored to individual storefronts. The InstrumentationKey.DefaultValue is automatically loaded from the Azure Application Insights connection string if provided, ensuring seamless integration with existing Azure resources.

## References
### QA-test:
### Jira-link:
### Artifact URL:
