### PR TITLE
VCST-2468: Add null check for TelemetryConfiguration object

### DIFF
--- a/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Serilog;
 using VirtoCommerce.ApplicationInsights.Core.Telemetry;
+using VirtoCommerce.Platform.Core.Modularity.Exceptions;
 
 namespace VirtoCommerce.ApplicationInsights.Data.Telemetry;
 
@@ -25,7 +26,7 @@ public static class ApplicationBuilderExtensions
 
         if (configuration == null)
         {
-            throw new ArgumentNullException(nameof(configuration), "TelemetryConfiguration is not initialized. Please make sure that another module doesn't override AppInsightsTelemetry.");
+            throw new ModuleInitializeException("TelemetryConfiguration is not initialized. Please make sure that another module doesn't override AppInsightsTelemetry.");
         }
 
         var samplingOptions = app.ApplicationServices.GetRequiredService<IOptions<ApplicationInsightsOptions>>().Value.SamplingOptions;

--- a/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
@@ -21,13 +21,8 @@ public static class ApplicationBuilderExtensions
     /// <returns></returns>
     public static IApplicationBuilder UseAppInsightsTelemetry(this IApplicationBuilder app)
     {
-        var configuration = app.ApplicationServices.GetService<TelemetryConfiguration>();
-
-        if (configuration == null)
-        {
-            Log.Error("TelemetryConfiguration is not initialized. Skipping AppInsights telemetry processors configuration.");
-            return app;
-        }
+        var configuration = app.ApplicationServices.GetService<TelemetryConfiguration>() ??
+            throw new Exception("TelemetryConfiguration is not initialized. Please make sure that another module doesn't override AppInsightsTelemetry.");
 
         var samplingOptions = app.ApplicationServices.GetRequiredService<IOptions<ApplicationInsightsOptions>>().Value.SamplingOptions;
         var builder = configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder;

--- a/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
@@ -21,10 +21,15 @@ public static class ApplicationBuilderExtensions
     /// <returns></returns>
     public static IApplicationBuilder UseAppInsightsTelemetry(this IApplicationBuilder app)
     {
-        var samplingOptions = app.ApplicationServices.GetRequiredService<IOptions<ApplicationInsightsOptions>>().Value.SamplingOptions;
-
         var configuration = app.ApplicationServices.GetService<TelemetryConfiguration>();
 
+        if (configuration == null)
+        {
+            Log.Error("TelemetryConfiguration is not initialized. Skipping AppInsights telemetry processors configuration.");
+            return app;
+        }
+
+        var samplingOptions = app.ApplicationServices.GetRequiredService<IOptions<ApplicationInsightsOptions>>().Value.SamplingOptions;
         var builder = configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder;
         if (samplingOptions.Processor == SamplingProcessor.Adaptive)
         {

--- a/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.ApplicationInsights.Data/Telemetry/ApplicationBuilderExtensions.cs
@@ -21,11 +21,16 @@ public static class ApplicationBuilderExtensions
     /// <returns></returns>
     public static IApplicationBuilder UseAppInsightsTelemetry(this IApplicationBuilder app)
     {
-        var configuration = app.ApplicationServices.GetService<TelemetryConfiguration>() ??
-            throw new Exception("TelemetryConfiguration is not initialized. Please make sure that another module doesn't override AppInsightsTelemetry.");
+        var configuration = app.ApplicationServices.GetService<TelemetryConfiguration>();
+
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration), "TelemetryConfiguration is not initialized. Please make sure that another module doesn't override AppInsightsTelemetry.");
+        }
 
         var samplingOptions = app.ApplicationServices.GetRequiredService<IOptions<ApplicationInsightsOptions>>().Value.SamplingOptions;
         var builder = configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder;
+
         if (samplingOptions.Processor == SamplingProcessor.Adaptive)
         {
             // Using adaptive rate sampling


### PR DESCRIPTION
## Description
fix: Add check if the `TelemetryConfiguration` object is null before configuring telemetry processors. If null, throw a user-friendly error message.


## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-2468
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ApplicationInsights_3.803.0-pr-7-46ba.zip