### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.808.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Telemetry\" />

--- a/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
@@ -6,9 +6,6 @@
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
-  <ItemGroup>
-    
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />

--- a/src/VirtoCommerce.ApplicationInsights.Data/VirtoCommerce.ApplicationInsights.Data.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Data/VirtoCommerce.ApplicationInsights.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
@@ -10,11 +10,10 @@
     <ProjectReference Include="..\VirtoCommerce.ApplicationInsights.Core\VirtoCommerce.ApplicationInsights.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="2.7.3" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.23.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.ApplicationInsights.Web/VirtoCommerce.ApplicationInsights.Web.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Web/VirtoCommerce.ApplicationInsights.Web.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.ApplicationInsights.Web/module.manifest
+++ b/src/VirtoCommerce.ApplicationInsights.Web/module.manifest
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.ApplicationInsights</id>
-  <version>3.808.0</version>
+  <version>3.1000.0</version>
   <version-tag>
   </version-tag>
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
   </dependencies>
   <apps>
@@ -29,7 +29,7 @@
   <assemblyFile>VirtoCommerce.ApplicationInsights.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.ApplicationInsights.Web.Module, VirtoCommerce.ApplicationInsights.Web</moduleType>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <groups>
     <group>commerce</group>

--- a/tests/VirtoCommerce.ApplicationInsights.Tests/VirtoCommerce.ApplicationInsights.Tests.csproj
+++ b/tests/VirtoCommerce.ApplicationInsights.Tests/VirtoCommerce.ApplicationInsights.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,13 +8,13 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ApplicationInsights_3.1000.0-pr-15-3553.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Framework and dependency upgrades can introduce runtime or build/test incompatibilities (especially telemetry and test tooling), but the changes are primarily configuration/package updates.
> 
> **Overview**
> Upgrades all projects in the module (including tests) from `net8.0` to `net10.0` and bumps the module version to `3.1000.0`.
> 
> Updates compatibility/dependencies to match the newer platform/tooling: `VirtoCommerce.Platform.Core`/`platformVersion` to `3.1002.0`, refreshes Application Insights/Serilog packages, and modernizes the test stack (newer `coverlet`, `Microsoft.NET.Test.Sdk`, and move to `xunit.v3`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355352413020fa375202aae36fb007ac205aac4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->