### PR TITLE
VCST-5163: Stable 15 — ApplicationInsights (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Core/VirtoCommerce.ApplicationInsights.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Telemetry\" />

--- a/src/VirtoCommerce.ApplicationInsights.Data/VirtoCommerce.ApplicationInsights.Data.csproj
+++ b/src/VirtoCommerce.ApplicationInsights.Data/VirtoCommerce.ApplicationInsights.Data.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>

--- a/src/VirtoCommerce.ApplicationInsights.Web/module.manifest
+++ b/src/VirtoCommerce.ApplicationInsights.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1004.0</version>
   <version-tag>
   </version-tag>
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
   </dependencies>
   <apps>


### PR DESCRIPTION
Part of **Stable 15** (Wave 1). Builds against the published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) from nuget.org.

- Platform -> **3.1039.0**; module version -> **3.1004.0**.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and manifest version alignment only; no application logic changes in the diff.
> 
> **Overview**
> Aligns the Application Insights module with **Stable 15** by targeting platform **3.1039.0** from nuget.org.
> 
> `VirtoCommerce.Platform.Core` is bumped from **3.1002.0** to **3.1039.0** in the Core project, and `module.manifest` **`platformVersion`** is updated to match. Project files also drop the UTF-8 BOM on the opening `<Project>` line (no functional change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9f690ec7e7040ea0695d8d93d9ecda7a8981f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ApplicationInsights_3.1004.0-pr-18-b9f6.zip